### PR TITLE
Tweak the display of Constituency and Party info on Members page

### DIFF
--- a/position/member-of-parliament.html
+++ b/position/member-of-parliament.html
@@ -36,23 +36,15 @@ title: Member of the National Assembly
     {% for person in site.people %}
     {% include person_collections.html %}
     <li class="position">
-
       <a href="{{ person.url }}">
-
         <img src="{{ person.image }}" alt="{{ person.name }}" width="50" height="50" />
-
         <span class="name">{{ person.name }}</span>
-
         <span class="more">more&hellip;</span>
       </a>
 
       <div>
-        Member of the National Assembly
-        for
-        <a href="{{ area.url }}">{{ area.name }}</a>
-        Member of
-        <a href="{{ party.url }}">{{ party.name }}</a>
-        .
+        Constituency: <a href="{{ area.url }}">{{ area.name }}</a> |
+        Party: <a href="{{ party.url }}">{{ party.name }}</a>
       </div>
 
     </li>


### PR DESCRIPTION
Just display them as simple key/value pairs, rather than trying to make a sentence out of them.

Before:
![screen shot 2015-12-03 at 13 20 25](https://cloud.githubusercontent.com/assets/57483/11561645/ac1b58b2-99c0-11e5-8a4c-b718e62f71d1.png)

After:
![screen shot 2015-12-03 at 13 20 02](https://cloud.githubusercontent.com/assets/57483/11561646/ac203c38-99c0-11e5-9017-b18a5d4d8e80.png)
