### PR TITLE
Use Party images if available

### DIFF
--- a/_layouts/organizations.html
+++ b/_layouts/organizations.html
@@ -10,7 +10,11 @@ layout: default
 </div>
 
 <div class="profile-pic">
-  {% image 'organisation-210x210.jpg' %}
+  {% if organization.image.to_s == blank %}
+    <img src="{{ organization.image }}" alt="{{ organization.name }}" width="50" />
+  {% else %}
+    {% image 'organisation-210x210.jpg' %}
+  {% endif %}
 </div>
 
 


### PR DESCRIPTION
If the EveryPolitician data has an image for a Party, display it instead of the default 'organization' image.

![screen shot 2015-12-03 at 19 42 52](https://cloud.githubusercontent.com/assets/57483/11572336/94c03a6a-99f8-11e5-8705-543854e8c47e.png)
![screen shot 2015-12-03 at 19 43 42](https://cloud.githubusercontent.com/assets/57483/11572335/94ba2382-99f8-11e5-8b3e-135844c5e254.png)
![screen shot 2015-12-03 at 19 53 29](https://cloud.githubusercontent.com/assets/57483/11572334/94b88748-99f8-11e5-8136-2e888c09d848.png)
