### PR TITLE
Remove old files on deploy

### DIFF
--- a/_bin/deploy
+++ b/_bin/deploy
@@ -19,7 +19,7 @@ build_and_deploy_jekyll_site() {
 
   git config user.name "everypoliticianbot"
   git config user.email "team@everypolitician.org"
-  git add .
+  git add --all .
   git commit -m "Deploy to GitHub Pages"
 
   # We redirect any output to /dev/null to hide any sensitive credential data


### PR DESCRIPTION
If a file hasn't been re-generated by Jekyll then it's not needed. We
tell git to track removal as well as addition with '--all'.
