### PR TITLE
Increase speed of generating search box

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,14 @@ remote_csv:
       assembly_people: kuvakazim_id
       senate_people: kuvakazim_id
 
+collections_to_search:
+  - assembly_people
+  - senate_people
+  - assembly_organizations
+  - senate_organizations
+  - assembly_areas
+  - senate_areas
+
 collections:
   executive_positions_by_role:
     output: true

--- a/_includes/search_select.html
+++ b/_includes/search_select.html
@@ -1,15 +1,4 @@
 <select class="search-autocomplete-name js-search-autocomplete-name">
   <option>name, place, party</option>
-  {% for person in site.assembly_people %}
-  <option value="{{ person.url }}">{{ person.name }}</option>
-  {% endfor %}
-  {% for person in site.senate_people %}
-  <option value="{{ person.url }}">{{ person.name }}</option>
-  {% endfor %}
-  {% for area in site.areas %}
-  <option value="{{ area.url }}">{{ area.name }}</option>
-  {% endfor %}
-  {% for organization in site.organizations %}
-  <option value="{{ organization.url }}">{{ organization.name }}</option>
-  {% endfor %}
+  {% search_options %}
 </select>

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -1,0 +1,20 @@
+module Jekyll
+  class SearchOptionsTag < Liquid::Tag
+    def render(context)
+      context.registers[:site].config['search_options'] ||= generate_search_options(context)
+    end
+
+    private
+
+    def generate_search_options(context)
+      site = context.registers[:site]
+      Array(site.config['collections_to_search']).map do |collection, field|
+        site.collections[collection].docs.map do |doc|
+          %Q(<option value="#{doc.url}">#{doc.data['name']}</option>)
+        end
+      end.flatten.compact.join("\n")
+    end
+  end
+
+  Liquid::Template.register_tag('search_options', Jekyll::SearchOptionsTag)
+end


### PR DESCRIPTION
Rather than generating this in liquid we simply do it in Ruby which cuts
the time to generate the site in half.

This should be extracted into a proper plugin Very Soon.

Fixes #47 
Fixes #54 
