### PR TITLE
Combine start_date and end_date if they're the same

### DIFF
--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -70,10 +70,10 @@ layout: default
 
       <span class="experience__term">
         {% if position.start_date %}
-        {{ position.start_date }} &ndash;
+        {{ position.start_date }}
         {% endif %}
-        {% if position.end_date %}
-        {{ position.end_date }}
+        {% if position.end_date and position.end_date != position.start_date %}
+        &ndash; {{ position.end_date }}
         {% endif %}
       </span>
       </a>
@@ -101,10 +101,10 @@ layout: default
 
       <span class="experience__term">
         {% if job.start_date %}
-        {{ job.start_date }} &ndash;
+        {{ job.start_date }}
         {% endif %}
-        {% if job.end_date %}
-        {{ job.end_date }}
+        {% if job.end_date and job.end_date != job.start_date %}
+        &ndash; {{ job.end_date }}
         {% endif %}
       </span>
     </li>


### PR DESCRIPTION
This stops odd dates like '2006 - 2006' from being displayed.

Closes #43 
