### PR TITLE
Make jekyll-search config clearer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/jekyll-search
-  revision: 490fc406e62549dae3c31f72c13fc03285cb8d8a
+  revision: 29b1baca590b60d436e63f17aab026b3de4a5f7d
   branch: master
   specs:
     jekyll-search (0.1.0)

--- a/_plugins/jekyll_search.rb
+++ b/_plugins/jekyll_search.rb
@@ -1,4 +1,5 @@
 Jekyll::Search::AlternativeSpellings.register :assembly_people, :senate_people do |person|
-  next [] unless person.data.key?('other_names')
-  person.data['other_names'].map { |on| on['name'] }
+  if person.data.key?('other_names')
+    person.data['other_names'].map { |other_name| other_name['name'] }
+  end
 end


### PR DESCRIPTION
There was a typo in the config where I'd written 'next []'. Instead of
just removing the errant array I've just wrapped the logic in an if
statement.

Fixes #87 
