### PR TITLE
Remove constituency filter from position pages

### DIFF
--- a/_includes/current_position_holders.html
+++ b/_includes/current_position_holders.html
@@ -1,21 +1,6 @@
 <div class="content_box">
   <h3>Current Position Holders</h3>
 
-  <div class="search-filters">
-    <form method="get">
-      <label for="place_slug">Constituency</label>
-
-      <select name="place_slug" id="place_slug">
-        <option value="">All</option>
-        {% for area in include.areas %}
-          <option value="{{ area.id }}">{{ area.name }}</option>
-        {% endfor %}
-      </select>
-
-      <input type="submit" value="Search" />
-    </form>
-  </div>
-
   <ul class="position-listing">
     {% for person in include.people %}
       {% include person_item.html %}


### PR DESCRIPTION
This doesn't work in it's current state so the simplest option is to
remove it. If people want to see the politicians for an area then they
can search for the area and go to the page for an individual area. These
pages then have a list of the representatives on them.

Fixes #77 
