### PR TITLE
Don't hotlink images

### DIFF
--- a/_includes/list_item.html
+++ b/_includes/list_item.html
@@ -11,7 +11,11 @@ Requires the following variables to be in the current scope:
 <li class="position">
   <a href="{{ person.url }}">
     <div class="image-wrapper">
-      <img src="{{ person.image }}" alt="{{ person.name }}" />
+      {% if person.image %}
+        <img src="{{ person.image }}" srcset="{{ person.image }}" alt="{{ person.name }}">
+      {% else %}
+        <img src="/images/person-210x210.jpg" alt="Person logo">
+      {% endif %}
     </div>
     <span class="listing__name">{{ person.name }}</span> <a class="listing__party" href="{{ party.url }}">{{ party.name }}</a>
   </a>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -9,7 +9,11 @@ layout: default
 
 <div class="title-space">
   <div class="profile-pic">
-    <img src="{{ person.image }}" srcset="{{ person.image }}" alt="{{ person.name }}">
+    {% if person.image %}
+      <img src="{{ person.image }}" srcset="{{ person.image }}" alt="{{ person.name }}">
+    {% else %}
+      <img src="/images/person-210x210.jpg" alt="Person logo">
+    {% endif %}
   </div>
   <div class="title-space__name">
     <h1>{{ person.name }}</h1>

--- a/_plugins/everypolitician_datasource.rb
+++ b/_plugins/everypolitician_datasource.rb
@@ -19,7 +19,6 @@ module Jekyll
     def generate(site)
       %w[assembly_people senate_people].each do |collection|
         site.collections[collection].docs.each do |person|
-          person.data['image'] ||= '/images/person-210x210.jpg'
           kuvakazim_identifer = person.data['identifiers'].find { |id| id['scheme'] == 'kuvakazim' }
           next unless kuvakazim_identifer
           person.data['kuvakazim_id'] = kuvakazim_identifer['identifier']

--- a/_plugins/image_cache.rb
+++ b/_plugins/image_cache.rb
@@ -1,0 +1,14 @@
+module Jekyll
+  class ImageCache < Jekyll::Generator
+    def generate(site)
+      %w[assembly_people senate_people].each do |collection|
+        site.collections[collection].docs.each do |person|
+          if person.data['image']
+            house = collection == 'assembly_people' ? 'Assembly' : 'Senate'
+            person.data['image'] = "https://everypolitician.github.io/zimbabwe-images/#{house}/#{person.data['id']}.jpeg"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of hotlinking use the images that are cached in the [zimbabwe-images](https://github.com/everypolitician/zimbabwe-images) repo by the [image-cache](https://github.com/everypolitician/image_cache) app which is running hourly on Heroku to update images.

Fixes #74 
