### PR TITLE
Remove CSS before regenerating on deploy

### DIFF
--- a/_bin/deploy
+++ b/_bin/deploy
@@ -3,8 +3,6 @@
 set -e # exit with nonzero exit code if anything fails
 
 build_and_deploy_jekyll_site() {
-  rm -rf _site
-
   tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
   github_url="https://${GITHUB_ACCESS_TOKEN}@github.com/${GITHUB_REPO_SLUG}"
 

--- a/_bin/deploy
+++ b/_bin/deploy
@@ -8,6 +8,9 @@ build_and_deploy_jekyll_site() {
 
   git clone --quiet --branch=gh-pages "$github_url" "${tmpdir}/gh-pages" > /dev/null 2>&1
 
+  # Remove compass generated css
+  rm -rf "${tmpdir}/gh-pages/css"
+
   # Build the jekyll site
   JEKYLL_ENV=production bundle exec jekyll build --destination "${tmpdir}/gh-pages" --trace
 


### PR DESCRIPTION
Due to the way jekyll-compass works we need to remove the css directory to ensure it gets regenerated correctly on each deploy.

Fixes #101 
