### PR TITLE
Integrate with prose.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,15 @@ collections:
     output: true
     permalink: '/senate/place/:path/'
 
+prose:
+  siteurl: http://staging.kuvakazim.com
+  relativeLinks: http://staging.kuvakazim.com/links.jsonp
+  media: media_root
+  ignore:
+    - '*'
+    - '!_posts'
+    - '!info'
+
 defaults:
   - scope:
       path: "info"

--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,32 @@ prose:
     - '*'
     - '!_posts'
     - '!info'
+  metadata:
+    _posts:
+      - name: layout
+        field:
+          element: hidden
+          value: post
+      - name: title
+        field:
+          element: text
+          label: Title
+          value: ""
+    info:
+      - name: layout
+        field:
+          element: hidden
+          value: page
+      - name: title
+        field:
+          element: text
+          label: Title
+          value: ""
+      - name: permalink
+        field:
+          element: text
+          label: Permalink
+          value: ""
 
 defaults:
   - scope:

--- a/_plugins/prose_io_links.rb
+++ b/_plugins/prose_io_links.rb
@@ -1,0 +1,34 @@
+module Jekyll
+  class LinksJsonpPage < Jekyll::Page
+    def initialize(site, base, dir, name)
+      @site = site
+      @base = base
+      @dir = dir
+      @name = name
+
+      process(@name)
+
+      pages_with_titles = site.pages.find_all { |p| p.data['title'] && p.data['title'] != '' }
+      pages_to_link = pages_with_titles.sort_by { |p| p.data['title'] }
+      posts_to_link = site.posts.docs.sort_by { |p| p.data['title'] }
+
+      links = (pages_to_link + posts_to_link).map do |p|
+        {
+          text: p.data['title'],
+          href: p.url
+        }
+      end
+
+      self.data = {}
+      self.content = "callback(#{JSON.pretty_generate(links)})"
+
+      Jekyll::Hooks.trigger :pages, :post_init, self
+    end
+  end
+
+  class ProseIoLinks < Jekyll::Generator
+    def generate(site)
+      site.pages << LinksJsonpPage.new(site, site.source, '', 'links.jsonp')
+    end
+  end
+end


### PR DESCRIPTION
This hides everything except the `_posts` and `info` directories for users editing on http://prose.io. It also adds a list of internal links so that when the user goes to insert a link on prose they can select from the existing links on the site.

Fixes #97 
