### PR TITLE
Add a published checkbox to prose metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,11 @@ prose:
           element: text
           label: Title
           value: ""
+      - name: published
+        field:
+          element: checkbox
+          label: Published
+          value: true
     info:
       - name: layout
         field:


### PR DESCRIPTION
This means that you can toggle the published state of a post easily. It
also defaults posts to being published.

Fixes #114 
