### PR TITLE
Make it easy to link to a collection in prose

### DIFF
--- a/_plugins/prose_io_links.rb
+++ b/_plugins/prose_io_links.rb
@@ -19,6 +19,15 @@ module Jekyll
         }
       end
 
+      site.collections.each do |_name, collection|
+        links += collection.docs.map do |doc|
+          {
+            text: doc.data['title'],
+            href: doc.url
+          }
+        end
+      end
+
       self.data = {}
       self.content = "callback(#{JSON.pretty_generate(links)})"
 


### PR DESCRIPTION
This adds all the collection items to links.jsonp to make it easy to
link to a person, organization etc from prose.io.

Fixes #112 
